### PR TITLE
Replace switch with polymorphism

### DIFF
--- a/lib/Movie.php
+++ b/lib/Movie.php
@@ -40,27 +40,7 @@ class Movie {
 	}
 
 	public function getCharge($daysRented) {
-		$result = 0;
-
-		switch ($this->getPriceCode()) {
-			case Movie::REGULAR :
-				$result += 2;
-				if ($daysRented > 2) {
-					$result += ($daysRented - 2) * 1.5;
-				}
-			break;
-			case Movie::NEW_RELEASE :
-				$result += $daysRented * 3;
-			break;
-			case Movie::CHILDREN :
-				$result += 1.5;
-				if ($daysRented > 3) {
-					$result += ($daysRented - 3) * 1.5;
-				}
-			break;
-		}
-
-		return $result;
+		return $this->_price->getCharge($daysRented);
 	}
 
 	public function getFrequentRenterPoints($daysRented) {

--- a/lib/Movie.php
+++ b/lib/Movie.php
@@ -24,6 +24,38 @@ class Movie {
 	public function getTitle() {
 		return $this->_title;
 	}
+
+	public function getCharge($daysRented) {
+		$result = 0;
+
+		switch ($this->getPriceCode()) {
+			case Movie::REGULAR :
+				$result += 2;
+				if ($daysRented > 2) {
+					$result += ($daysRented - 2) * 1.5;
+				}
+			break;
+			case Movie::NEW_RELEASE :
+				$result += $daysRented * 3;
+			break;
+			case Movie::CHILDREN :
+				$result += 1.5;
+				if ($daysRented > 3) {
+					$result += ($daysRented - 3) * 1.5;
+				}
+			break;
+		}
+
+		return $result;
+	}
+
+	public function getFrequentRenterPoints($daysRented) {
+		if (($this->getPriceCode() == Movie::NEW_RELEASE) && ($daysRented > 1)) {
+				return 2;
+		} else {
+			return 1;
+		}
+	}
 }
 
 ?>

--- a/lib/Movie.php
+++ b/lib/Movie.php
@@ -1,24 +1,38 @@
 <?php
 
+require_once 'Price.php';
+
 class Movie {
 	const CHILDREN = 2;
 	const REGULAR = 0;
 	const NEW_RELEASE = 1;
 
 	private $_title;
-	private $_priceCode;
+	private $_price;
 
 	public function __construct($title, $priceCode) {
 		$this->_title = $title;
-		$this->_priceCode = $priceCode;
+		$this->setpriceCode($priceCode);
 	}
 
 	public function getPriceCode() {
-		return $this->_priceCode;
+		return $this->_price->getPriceCode();
 	}
 
 	public function setPriceCode($arg) {
-		$this->_priceCode = $arg;
+		switch ($arg) {
+			case self::REGULAR :
+				$this->_price = new RegularPrice;
+			break;
+			case self::CHILDREN :
+				$this->_price = new ChildrensPrice;
+			break;
+			case self::NEW_RELEASE :
+				$this->_price = new NewReleasePrice;
+			break;
+			default :
+				throw new InvalidArgumentException('Incorrect Price Code');
+		}
 	}
 
 	public function getTitle() {

--- a/lib/Movie.php
+++ b/lib/Movie.php
@@ -44,11 +44,7 @@ class Movie {
 	}
 
 	public function getFrequentRenterPoints($daysRented) {
-		if (($this->getPriceCode() == Movie::NEW_RELEASE) && ($daysRented > 1)) {
-				return 2;
-		} else {
-			return 1;
-		}
+		return $this->_price->getFrequentRenterPoints($daysRented);
 	}
 }
 

--- a/lib/Price.php
+++ b/lib/Price.php
@@ -5,6 +5,10 @@ require_once 'Movie.php';
 abstract class Price {
 	abstract public function getPriceCode();
 	abstract public function getCharge($daysRented);
+
+	public function getFrequentRenterPoints($daysRented) {
+		return 1;
+	}
 }
 
 class ChildrensPrice extends Price {
@@ -29,6 +33,10 @@ class NewReleasePrice extends Price {
 
 	public function getCharge($daysRented) {
 		return $daysRented * 3;
+	}
+
+	public function getFrequentRenterPoints($daysRented) {
+		return ($daysRented > 1) ? 2: 1;
 	}
 }
 

--- a/lib/Price.php
+++ b/lib/Price.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once 'Movie.php';
+
+abstract class Price {
+	abstract public function getPriceCode();
+}
+
+class ChildrensPrice extends Price {
+	public function getPriceCode() {
+		return Movie::CHILDREN;
+	}
+}
+
+class NewReleasePrice extends Price {
+	public function getPriceCode() {
+		return Movie::NEW_RELEASE;
+	}
+}
+
+class RegularPrice extends Price {
+	public function getPriceCode() {
+		return Movie::REGULAR;
+	}
+}
+
+?>

--- a/lib/Price.php
+++ b/lib/Price.php
@@ -4,11 +4,21 @@ require_once 'Movie.php';
 
 abstract class Price {
 	abstract public function getPriceCode();
+	abstract public function getCharge($daysRented);
 }
 
 class ChildrensPrice extends Price {
 	public function getPriceCode() {
 		return Movie::CHILDREN;
+	}
+
+	public function getCharge($daysRented) {
+		$result = 1.5;
+		if ($daysRented > 3) {
+			$result += ($daysRented - 3) * 1.5;
+		}
+
+		return $result;
 	}
 }
 
@@ -16,11 +26,24 @@ class NewReleasePrice extends Price {
 	public function getPriceCode() {
 		return Movie::NEW_RELEASE;
 	}
+
+	public function getCharge($daysRented) {
+		return $daysRented * 3;
+	}
 }
 
 class RegularPrice extends Price {
 	public function getPriceCode() {
 		return Movie::REGULAR;
+	}
+
+	public function getCharge($daysRented) {
+		$result = 2;
+		if ($daysRented > 2) {
+			$result += ($daysRented - 2) * 1.5;
+		}
+
+		return $result;
 	}
 }
 

--- a/lib/Rental.php
+++ b/lib/Rental.php
@@ -20,36 +20,11 @@ class Rental {
 	}
 
 	public function getCharge() {
-		$result = 0;
-
-		switch ($this->getMovie()->getPriceCode()) {
-			case Movie::REGULAR :
-				$result += 2;
-				if ($this->getDaysRented() > 2) {
-					$result += ($this->getDaysRented() - 2) * 1.5;
-				}
-			break;
-			case Movie::NEW_RELEASE :
-				$result += $this->getDaysRented() * 3;
-			break;
-			case Movie::CHILDREN :
-				$result += 1.5;
-				if ($this->getDaysRented() > 3) {
-					$result += ($this->getDaysRented() - 3) * 1.5;
-				}
-			break;
-		}
-
-		return $result;
+		return $this->_movie->getCharge($this->_daysRented);
 	}
 
 	public function getFrequentRenterPoints() {
-		if (($this->getMovie()->getPriceCode() == Movie::NEW_RELEASE) &&
-			($this->getDaysRented() > 1)) {
-				return 2;
-		} else {
-			return 1;
-		}
+		return $this->_movie->getFrequentRenterPoints($this->_daysRented);
 	}
 }
 

--- a/tests/CustomerTest.php
+++ b/tests/CustomerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require 'lib/Customer.php';
+require_once 'lib/Customer.php';
 
 class CustomerTest extends PHPUnit_Framework_TestCase {
 

--- a/tests/MovieTest.php
+++ b/tests/MovieTest.php
@@ -1,0 +1,47 @@
+<?php
+
+require_once 'lib/Movie.php';
+
+class MovieTest extends PHPUnit_Framework_TestCase {
+
+	public function testName() {
+		$sw = new Movie('Star Wars', Movie::REGULAR);
+		$this->assertEquals('Star Wars', $sw->getTitle());
+	}
+
+	public function testPriceCode() {
+		$sw = new Movie('Star Wars', Movie::REGULAR);
+		$this->assertEquals(Movie::REGULAR, $sw->getPriceCode());
+
+		$toystory = new Movie('Toy Story', Movie::CHILDREN);
+		$this->assertEquals(Movie::CHILDREN, $toystory->getPriceCode());
+
+		$skyfall = new Movie('Skyfall', Movie::NEW_RELEASE);
+		$this->assertEquals(Movie::NEW_RELEASE, $skyfall->getPriceCode());
+	}
+
+	public function testInvalidPriceCode() {
+		$this->setExpectedException('InvalidArgumentException');
+		$killbill = new Movie('Kill Bill', 999);
+	}
+
+	public function testChargeRegular() {
+		$sw = new Movie('Star Wars', Movie::REGULAR);
+		$this->assertEquals(2, $sw->getCharge(1));
+		$this->assertEquals(3.5, $sw->getCharge(3));
+	}
+
+	public function testChargeNewRelease() {
+		$skyfall = new Movie('Skyfall', Movie::NEW_RELEASE);
+		$this->assertEquals(6, $skyfall->getCharge(2));
+	}
+
+	public function testChargeChildren() {
+		$toystory = new Movie('Toy Story', Movie::CHILDREN);
+		$this->assertEquals(1.5, $toystory->getCharge(2));
+		$this->assertEquals(1.5, $toystory->getCharge(3));
+		$this->assertEquals(3, $toystory->getCharge(4));
+	}
+}
+
+?>


### PR DESCRIPTION
Since we can't simply replace the switch statement by using 3 movies subclasses (because a movie can change its classification during its lifetime), we use the State Pattern and introduce a Price Class

First we move the type code behavior into the state pattern with **Replace Type Code with State/Strategy**. Then I can use **Move Method** to move the switch statement into the price class. Finally we use **Replace Conditional with Polymorphism** to eliminate the switch statement.

Done both for `getCharge` and `getFrequentRenterPoints` methods
